### PR TITLE
Reviderte vedtekter

### DIFF
--- a/vedtekter.md
+++ b/vedtekter.md
@@ -1,63 +1,77 @@
 # Vedtekter for Offentlig PaaS
 
-Vedtekter for Offentlig PaaS. Vedtatt av stiftelsesmøtet 11.12.2024
+Vedtekter for Offentlig PaaS. Vedtatt av stiftelsesmøtet 11.12.2024, revidert på årsmøtet 2025.
 
 ## § 1 Formål
+
 Offentlig PaaS er en interesseorganisasjon for platformutviklere som jobber i offentlig sektor.
 
 Offentlig PaaS skal:
+
 * jobbe for å dele kunnskap om plattform og temaer under plattform.
 * fungere som et kontaktnettverk og samarbeidsforum for de som jobber med eller er interesserte i plattform.
 * være et samlingspunkt for plattformutviklere i offentlig sektor.
 
-
 ## § 2 Organisatorisk tilknytning
-Alle som er ansatt i offentlig sektor, eller selskaper hvor offentligheten er majoritetseier, kan bli medlem. Medlemskap tildeles automatisk ved registrering i Offentlig PaaS Slacken.
 
-## § 3 Medlemmer
-Medlemmer i foreningen er personer som har meldt seg til å arrangere faglige arrangementer i Offentlig PaaS.
+Alle som er ansatt i offentlig sektor, eller selskaper hvor offentligheten er majoritetseier, kan bli medlem.
+
+## § 3 Medlemmskap
+
+Medlemskap tildeles automatisk ved registrering i Offentlig PaaS Slacken.
 
 ## § 4 Stemmerett og valgbarhet
-Alle medlemmer har stemmerett og er valgbare til tillitsverv i foreningen.
+
+Alle registrerte organisasjoner har én stemme hver, og alle registrerte medlemmer er valgbare til tillitsverv i Offentlig PaaS.
 
 ## § 5 Årsmøte
+
 Årsmøtet er Offentlig PaaS høyeste myndighet. Årsmøtet holdes hvert år innen slutten av april og innkalles av styret med 1 måneds varsel med skriftlig melding til medlemmene. Forslag som skal behandles på årsmøtet skal være sendt til styret senest 2 uker før årsmøtet. Fullstendig saksliste må være tilgjengelig for medlemmene senest 1 uke før årsmøtet.
 
 Alle medlemmer har adgang til årsmøtet. Årsmøtet kan invitere andre personer og/eller media til å være til stede.
 
-Årsmøtet er vedtaksført med det antall stemmer som møter. Ingen har mer enn en stemme, og stemmegivning kan ikke skje ved fullmakt. Med mindre annet er bestemt skal et vedtak for å være gyldig være truffet med alminnelig flertall av de avgitte stemmene. Blanke stemmer skal anses som ikke avgitt.
+Årsmøtet er vedtaksført med det antall stemmer som møter. Ingen organisasjon har mer enn én stemme, og stemmegivning kan ikke skje ved fullmakt. Med mindre annet er bestemt skal et vedtak for å være gyldig være truffet med alminnelig flertall av de avgitte stemmene. Blanke stemmer skal anses som ikke avgitt.
 
 ## § 6 Årsmøtets oppgaver
+
 Årsmøtet skal:
-* Behandle Offentlig PaaS årsmelding
-* Behandle Offentlig PaaS regnskap i revidert stand
-* Behandle innkomne forslag
-* Vedta Offentlig PaaS budsjett
+
+* Behandle Offentlig PaaS årsmelding.
+* Behandle Offentlig PaaS regnskap i revidert stand.
+* Behandle innkomne forslag.
+* Vedta Offentlig PaaS budsjett.
 * Velge:
-  1. styremedlem(mer)
+  1. styreleder, nestleder og ett vanlig styremedlem. For å sikre kontinuitet velges alle medlemmene til styret for 2 år, men dersom to eller flere av styret står til valg velges en av dem for ett år. Slik oppnås at minst ett medlem av styret alltid er på valg hvert år.
 
 ## § 7 Ekstraordinære årsmøter
-Ekstraordinære årsmøter holdes når styret bestemmer det, eller minst en tredjedel av de stemmeberettigede medlemmene krever det.
 
-Møteinnkallelse og vedtak skjer etter samme regler som for ordinære årsmøter
+Ekstraordinære årsmøter holdes når styret bestemmer det, eller minst en tredjedel av de stemmeberettigede organisasjonene krever det.
+
+Møteinnkallelse og vedtak skjer etter samme regler som for ordinære årsmøter.
 
 ## § 8 Styret
+
 Offentlig PaaS ledes av styret som er høyeste myndighet mellom årsmøtene.
 
 Styret skal:
-* Iverksette årsmøtets bestemmelser
-* Oppnevne etter behov komiteer/utvalg/personer for spesielle oppgaver og utarbeide instruks for disse
-* Administrere og føre nødvendig kontroll med Offentlig PaaS økonomi og eiendeler i henhold til de til enhver tid gjeldende instrukser og bestemmelser
-* Representere Offentlig PaaS utad
+
+* Iverksette årsmøtets bestemmelser.
+* Oppnevne etter behov komiteer/utvalg/personer for spesielle oppgaver og utarbeide instruks for disse.
+* Administrere og føre nødvendig kontroll med Offentlig PaaS økonomi og eiendeler i henhold til de til enhver tid gjeldende instrukser og bestemmelser.
+* Representere Offentlig PaaS utad.
 * Leder innkaller til styremøter ved behov. Styret er vedtaksført når et flertall av styrets medlemmer er til stede. Vedtak fattes med flertall av de avgitte stemmene. Ved stemmelikhet gjelder det som styrelederen, eller stedfortreder utpekt av styreleder, har stemt for.
+* Kalle inn til årsmøte ihht. § 5.
 
 ## § 9 Grupper/avdelinger
-Offentlig PaaS kan organiseres med avdelinger og/eller grupper. Disse kan ledes av oppnevnte tillitspersoner. Offentlig PaaS styre bestemmer opprettelsen av avdelinger/grupper, og hvordan disse skal organiseres og ledes. Styret har plikt overfor årsmøtet til å rapportere om aktivitet i de ulike avdelinger/grupper.
+
+Offentlig PaaS kan organiseres med avdelinger og/eller grupper. Disse kan ledes av oppnevnte tillitspersoner. Styret i Offentlig PaaS bestemmer opprettelsen av avdelinger/grupper, og hvordan disse skal organiseres og ledes. Styret har plikt overfor årsmøtet til å rapportere om aktivitet i de ulike avdelinger/grupper.
 
 For avdelinger/gruppers økonomiske forpliktelser hefter hele Offentlig PaaS, og avdelinger/grupper kan ikke inngå avtaler eller representere Offentlig PaaS utad uten styrets godkjennelse.
 
 ## § 10 Vedtektsendringer
+
 Endringer i disse vedtekter kan bare foretas på ordinært eller ekstraordinært årsmøte etter å ha vært på sakslisten, og det kreves 2/3 flertall av de avgitte stemmene.
 
 ## § 11 Oppløsning (§ 11 kan ikke endres.)
+
 Oppløsning av Offentlig PaaS kan bare behandles på ordinært årsmøte. Blir oppløsning vedtatt med minst 2/3 flertall, innkalles ekstraordinært årsmøte 3 måneder senere. For at oppløsning skal skje må vedtaket her gjentas med 2/3 flertall.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -22,7 +22,8 @@ Medlemskap tildeles automatisk ved registrering i Offentlig PaaS Slacken.
 
 ## § 4 Stemmerett og valgbarhet
 
-Alle registrerte organisasjoner har én stemme hver, og alle registrerte medlemmer er valgbare til tillitsverv i Offentlig PaaS.
+Alle registrerte medlemmer er valgbare til tillitsverv i Offentlig PaaS, og alle organisasjoner representert av medlemmene tildeles én stemme hver.
+
 
 ## § 5 Årsmøte
 


### PR DESCRIPTION
Revidere og klargjøre Offentlig PaaS vedtekter. De viktigste endringene inkluderer oppdateringer til medlemskapskriterier, stemmerettigheter og strukturen til styret.

**Oppdateringer til medlemskap og stemmerettigheter:**

* Revidert medlemskapsseksjonen for å klargjøre at medlemskap automatisk tildeles ved registrering i Offentlig PaaS Slack.
* Oppdatert stemmerettigheter for å spesifisere at alle registrerte organisasjoner har én stemme hver, og alle registrerte medlemmer er kvalifiserte for tillitsverv.

**Endringer i styrets struktur:**

* Spesifisert valgprosessen for styreleder, nestleder, og styremedlemmer, inkludert vilkår og betingelser for å sikre kontinuitet.

**Ytterligere presiseringer:**

* Oppdatert vedtektene for å reflektere at ekstraordinære generalforsamlinger kan begjæres av en tredjedel av de stemmeberettigede organisasjonene, ikke individuelle medlemmer.
* Lagt til et krav om at styret skal innkalle til årsmøter i henhold til de spesifiserte reglene.



*Endringer i vedtektene følger krav om 2/3 flertall på årsmøte.*